### PR TITLE
feat: blogsync設定の追加とdevcontainer設定の整理

### DIFF
--- a/.config/blogsync/config.yaml
+++ b/.config/blogsync/config.yaml
@@ -1,0 +1,5 @@
+kiririmode.hatenablog.jp:
+  username: kiririmode
+  password: TODO
+default:
+  local_root: /Users/kiririmode/src/github.com/kiririmode/blog/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,6 @@
     "ghcr.io/devcontainers-extra/features/direnv:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
-  "mounts": [
-    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
-  ],
   "customizations": {
     "vscode": {
       "settings": {

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ deploy: deploy-config
 
 # Create symbolic links for .config subdirectories individually
 # This avoids overwriting existing ~/.config directory
-CONFIG_ITEMS := ghostty git karabiner mise peco starship.toml
+CONFIG_ITEMS := ghostty git karabiner mise peco starship.toml blogsync
 deploy-config:
 	@echo '===> Deploying .config items...'
 	@mkdir -p $(HOME)/.config


### PR DESCRIPTION
## 前提

### 背景
はてなブログの記事管理にblogsyncを使用しているが、設定ファイルがdotfilesで管理されていなかった。

### 課題
- blogsyncの設定を新しい環境で都度作成する必要があった
- devcontainerに不要なマウント設定が残っていた

## 目的

blogsyncの設定ファイルをdotfilesで一元管理し、新しい環境でも`make deploy`で自動的に設定が配置されるようにする。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `.config/blogsync/config.yaml` | blogsync設定ファイルを新規追加 |
| `Makefile` | `CONFIG_ITEMS`に`blogsync`を追加してデプロイ対象に含めた |
| `.devcontainer/devcontainer.json` | 不要な`~/.claude`マウント設定を削除 |

## 変更のスコープ

### 含むもの
- blogsync設定ファイルの追加
- デプロイ設定の更新
- devcontainer設定の整理

### 含まないもの
- blogsyncのインストール処理（Brewfile等への追加）
- パスワードの設定（TODOプレースホルダーのまま）

## 変更の視覚化

```mermaid
flowchart TB
    subgraph Before["変更前"]
        direction TB
        B_Make["Makefile<br/>CONFIG_ITEMS"]
        B_Items["ghostty, git, karabiner,<br/>mise, peco, starship.toml"]
        B_Make --> B_Items
    end

    subgraph After["変更後"]
        direction TB
        A_Make["Makefile<br/>CONFIG_ITEMS"]
        A_Items["ghostty, git, karabiner,<br/>mise, peco, starship.toml"]
        A_New["blogsync"]
        A_Make --> A_Items
        A_Make --> A_New
        style A_New fill:#90EE90
    end

    Before ~~~ After
```

```mermaid
flowchart LR
    subgraph Deploy["make deploy 実行時"]
        direction TB
        CMD["make deploy"]
        DC["deploy-config"]
        SYM["シンボリックリンク作成"]
        
        CMD --> DC
        DC --> SYM
        
        subgraph Target["~/.config/"]
            blogsync["blogsync/"]
            others["その他設定..."]
        end
        
        SYM --> Target
        style blogsync fill:#90EE90
    end
```

## 動作確認方法

1. dotfilesをクローンまたはpull
   ```bash
   git pull origin feat/blogsync
   ```

2. デプロイを実行
   ```bash
   make deploy
   ```

3. シンボリックリンクが作成されていることを確認
   ```bash
   ls -la ~/.config/blogsync
   # -> /path/to/dotfiles/.config/blogsync へのシンボリックリンクであること
   ```

4. 設定ファイルの内容を確認
   ```bash
   cat ~/.config/blogsync/config.yaml
   ```

## リスク・注意点

- **パスワード設定**: `config.yaml`内の`password`フィールドは`TODO`プレースホルダーになっている。実際に使用する際は環境変数や別の方法でパスワードを設定する必要がある
- **local_root パス**: デフォルトのlocal_rootパスが`/Users/kiririmode/...`とハードコードされているため、異なるユーザー名の環境では修正が必要
